### PR TITLE
Fixes bug adding a listener

### DIFF
--- a/src/Eventually.cpp
+++ b/src/Eventually.cpp
@@ -79,17 +79,22 @@ void EvtContext::setupContext() {
 }
   
 void EvtContext::addListener(EvtListener *lstn) {
-  for(int i = 0; i < listenerCount; i++) { // Try to add in empty slot
-    if(listeners[listenerCount] == 0) { 
-      listeners[listenerCount] = lstn;
-      return;
+  int i = 0;
+
+  // find the first empty slot
+  for(; i < listenerCount; i++) {
+    if(listeners[i] == 0) {
+      break;
     }
   }
 
-  // No empty slot, just add it
-  listeners[listenerCount] = lstn;
+  // if we didn't find one, expand
+  if(i == listenerCount) {
+    listenerCount++;
+  }
+  
+  listeners[i] = lstn;
   lstn->setupListener();
-  listenerCount++;
 }
 
 void EvtContext::removeListener(EvtListener *lstn) {


### PR DESCRIPTION
Fixes johnnyb/Eventually#6 and probably johnnyb/Eventually#5.

The original implementation fails to call `lstn->setupListener();` in the case where a spot was re-used. @jaredwhite128 avoids duplicating the code by not returning early.